### PR TITLE
add overflow to events-wrapper

### DIFF
--- a/src/vue-event-calendar.vue
+++ b/src/vue-event-calendar.vue
@@ -138,6 +138,7 @@ export default {
       left: 50%;
       top: 0;
       bottom: 0;
+      overflow: scroll;
     }
   }
 }


### PR DESCRIPTION
the layout collapses when there are so many events to show