### PR TITLE
ru locale change

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -74,8 +74,8 @@ export default {
   ru: {
     dayNames: ["Вс", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"],
     monthNames: ["Январь", "Февраль", "Март", "Апрель", "Май", "Июнь", "Июль", "Август", "Сентябрь", "Октябрь", "Ноябрь", "Декабрь"],
-    format: 'MM/yyyy',
-    fullFormat: 'dd/MM/yyyy',
+    format: 'MM.yyyy',
+    fullFormat: 'dd.MM.yyyy',
     dayEventsTitle: 'Все события',
     notHaveEvents: 'События отсутствуют'
   },


### PR DESCRIPTION
In Russia, date format notation is not using slashes. Instead, they are using dots.
https://en.wikipedia.org/wiki/Date_and_time_notation_in_Russia

Right now:

```
    format: 'MM/yyyy',
    fullFormat: 'dd/MM/yyyy',
```

Should be:

```
    format: 'MM.yyyy',
    fullFormat: 'dd.MM.yyyy',
```